### PR TITLE
fix: add retry and model fallback for AI synthesis

### DIFF
--- a/src/app/api/synthesize/route.ts
+++ b/src/app/api/synthesize/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { auth as adminAuth, db as adminDb } from "@/lib/firebase/server";
-import { Timestamp } from "firebase-admin/firestore";
 
 // Simple in-memory rate limiter (Token Bucket)
 const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
@@ -23,6 +22,72 @@ function checkRateLimit(uid: string) {
 
     record.count++;
     return true;
+}
+
+const MODELS = ["gemini-2.0-flash", "gemini-2.0-flash-lite"];
+const MAX_RETRIES = 2;
+
+function buildPrompt(questions: any[], responses: any[]): string {
+    const inputs = questions.map((q: any) => {
+        const answers = responses
+            .map((r: any) => r.answers ? r.answers[q.id] : undefined)
+            .filter((a: any) => a && typeof a === 'string');
+        return { question: q.text, answers };
+    });
+
+    return `
+      You are an expert pedagogical consultant for a Harvard graduate course.
+      Analyze the following student responses across the entire session.
+      Do not summarize; diagnose. Identify patterns in understanding and misconceptions.
+
+      Session Data:
+      ${JSON.stringify(inputs)}
+
+      Output JSON only matching this schema:
+      {
+        "executive_summary": "String (High-level summary of the class's performance and engagement)",
+        "common_misconceptions": ["String", "String (Cross-cutting misunderstandings observed)"],
+        "engagement_analysis": "String (Analysis of how students engaged with the material)",
+        "teaching_recommendations": ["String", "String (Specific, actionable 2-minute interventions for the professor)"]
+      }
+    `;
+}
+
+async function generateWithRetry(genAI: GoogleGenerativeAI, prompt: string): Promise<object> {
+    let lastError: Error | null = null;
+
+    for (const modelName of MODELS) {
+        const model = genAI.getGenerativeModel({
+            model: modelName,
+            generationConfig: { responseMimeType: "application/json" }
+        });
+
+        for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                if (attempt > 0) {
+                    await new Promise(res => setTimeout(res, 1000 * attempt));
+                }
+
+                const result = await model.generateContent(prompt);
+                const text = result.response.candidates?.[0]?.content?.parts?.[0]?.text;
+                if (!text) throw new Error("Empty response from AI");
+
+                return JSON.parse(text);
+            } catch (err) {
+                lastError = err as Error;
+                console.warn(`Attempt ${attempt + 1}/${MAX_RETRIES + 1} failed with ${modelName}:`, lastError.message);
+            }
+        }
+        console.warn(`All retries exhausted for ${modelName}, trying next model...`);
+    }
+
+    const message = lastError?.message || "Failed to synthesize";
+    const isRateLimit = message.toLowerCase().includes("rate") || message.toLowerCase().includes("quota");
+    throw new Error(
+        isRateLimit
+            ? "AI service is temporarily rate limited. Please wait a minute and try again."
+            : `Synthesis failed after retrying: ${message}`
+    );
 }
 
 export async function POST(req: Request) {
@@ -47,12 +112,10 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Session ID required" }, { status: 400 });
         }
 
-        // Rate Limit Check
         if (!checkRateLimit(decodedToken.uid)) {
             return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
         }
 
-        // Check Session Ownership
         const sessionDoc = await adminDb.collection("sessions").doc(sessionId).get();
         if (!sessionDoc.exists) {
             return NextResponse.json({ error: "Session not found" }, { status: 404 });
@@ -67,51 +130,13 @@ export async function POST(req: Request) {
         if (!apiKey) throw new Error("Missing API Key");
 
         const genAI = new GoogleGenerativeAI(apiKey);
-        const model = genAI.getGenerativeModel({
-            model: "gemini-2.0-flash",
-            generationConfig: {
-                responseMimeType: "application/json"
-            }
-        });
+        const prompt = buildPrompt(questions, responses);
+        const result = await generateWithRetry(genAI, prompt);
 
-        // Construct a prompt that aggregates all questions and responses
-        const inputs = questions.map((q: any) => {
-            const answers = responses
-                .map((r: any) => r.answers ? r.answers[q.id] : undefined)
-                .filter((a: any) => a && typeof a === 'string');
-            return {
-                question: q.text,
-                answers: answers
-            };
-        });
-
-        const prompt = `
-      You are an expert pedagogical consultant for a Harvard graduate course. 
-      Analyze the following student responses across the entire session. 
-      Do not summarize; diagnose. Identify patterns in understanding and misconceptions.
-
-      Session Data:
-      ${JSON.stringify(inputs)}
-      
-      Output JSON only matching this schema:
-      {
-        "executive_summary": "String (High-level summary of the class's performance and engagement)",
-        "common_misconceptions": ["String", "String (Cross-cutting misunderstandings observed)"],
-        "engagement_analysis": "String (Analysis of how students engaged with the material)",
-        "teaching_recommendations": ["String", "String (Specific, actionable 2-minute interventions for the professor)"]
-      }
-    `;
-
-        const result = await model.generateContent(prompt);
-        const response = await result.response;
-        const text = response.candidates?.[0]?.content?.parts?.[0]?.text;
-
-        if (!text) throw new Error("No response from AI");
-
-        return NextResponse.json(JSON.parse(text));
+        return NextResponse.json(result);
     } catch (error) {
         const e = error as Error;
         console.error("AI Error:", error);
-        return NextResponse.json({ error: e.message || "Failed to synthesize" }, { status: 500 });
+        return NextResponse.json({ error: e.message || "Failed to synthesize" }, { status: 503 });
     }
 }


### PR DESCRIPTION
## Summary
- [x] Added automatic retry (up to 2 retries with backoff delay) before giving up on a model.
- [x] Added fallback to `gemini-2.0-flash-lite` if `gemini-2.0-flash` fails all retries.
- [x] Wrapped `JSON.parse` in try/catch — malformed AI responses now retry instead of crashing.
- [x] Improved error messages — rate limit errors now tell the professor to wait, other errors include the failure reason.
- [x] Extracted `buildPrompt` and `generateWithRetry` from the route handler for cleaner separation of concerns.

## How it works now
When a professor clicks "Synthesize Session":

1. Try `gemini-2.0-flash` up to 3 times (with 1s, 2s delays between retries).
2. If all 3 attempts fail, try `gemini-2.0-flash-lite` up to 3 times.
3. If everything fails, return a clear error message explaining why (rate limit vs other).

Previously, a single failure on the first attempt would immediately show "Failed to synthesize" with no retry.

## What changed in the code
The route handler (`/api/synthesize`) previously had prompt building, AI calling, and HTTP handling all mixed together. Now:
- `buildPrompt()` — turns questions + responses into the AI prompt.
- `generateWithRetry()` — handles the retry loop across models, returns parsed JSON or throws with a clear message.
- `POST()` — handles auth, validation, ownership check, then delegates to the above.

Closes #18